### PR TITLE
Sprint4b: timeline view

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,6 @@ navigation:
   - url: /dashboard
 
 exclude:
-- '*.log'
-- node_modules
-- src
+  - '*.log'
+  - node_modules
+  - src

--- a/_includes/due_label.html
+++ b/_includes/due_label.html
@@ -2,10 +2,14 @@
 {% assign _due_status = _due_days | due_status %}
 <time class="due" datetime="{{ include.date }}"
   {% if _due_status %}data-status="{{ _due_status }}"{% endif %}>
-  {% if _due_status == 'over' %}
-    Overdue
+  {% if _due_days < 0 %}
+    Overdue by {% assign _due_days = 0 | minus: _due_days %}
+  {% elsif _due_days == 0 %}
+    Due today
   {% else %}
     Due in
   {% endif %}
-  {{ _due_days }} day{{ _due_days | pluralize }}
+  {% if _due_days != 0 %}
+    {{ _due_days }} day{{ _due_days | pluralize }}
+  {% endif %}
 </time>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,10 +35,10 @@
     <div class="wrapper wrapper__match-content">
       <div class="block block__sub">
         {% if page.subtitle %}
-        <h2>{{ page.subtitle }}</h2>
+        <h2 data-bind="subtitle">{{ page.subtitle }}</h2>
         {% endif %}
         <div class="header u-clearfix">
-          <h1 class="header__left superheading">{{ page.title | default: site.title }}</h1>
+          <h1 data-bind="title" class="header__left superheading">{{ page.title | default: site.title }}</h1>
           {% assign _user = site.data.users[site.user] %}
           {% if _user %}
           <h6 class="header__right">

--- a/_procurements/enforcement-compliance-orders-bpa-call.md
+++ b/_procurements/enforcement-compliance-orders-bpa-call.md
@@ -93,7 +93,7 @@ milestones:
     status: complete
     section_id: 1
     history: [
-      "CFPBuy Request # xxx-xxxx-xxx approved by OCFO on July 29, 2016.",
+      "CFPBuy Request # XXX-XXXX-XXX approved by OCFO on July 29, 2016.",
       "CFPBuy Request submitted by Myra (COR) on July 15, 2016."
     ]
 
@@ -102,7 +102,7 @@ tasks:
   # each task has:
   # 1. "content", which is markdown, and will be processed in the same
   #    way as activity messages (see above).
-  - message: "[CFPBuy Request] (locked) approved by OCFO"
+  - message: "[CFPBuy Request] (**locked**) approved by OCFO"
     due_date: 2016-08-03
     milestone_id: 5
     status: complete
@@ -140,7 +140,7 @@ links:
     # 2. "href": an absolute URI, e.g. "/sprint4b/documents/..."
     href: "/sprint4b/document/?title=CFPB+Buy+Request+%23+XXX-XXXX-XXX&locked=true"
   - name: "Determine milestones and timeline"
-    href: /sprint4b/determine/
+    href: /sprint4b/timeline/
   - name: "Draft ICGE v.1"
     href: "/sprint4b/document?title=Draft+ICGE+Timeline&version=1"
   - name: "Draft Performance Work Statement"

--- a/_procurements/enforcement-compliance-orders-bpa-call.md
+++ b/_procurements/enforcement-compliance-orders-bpa-call.md
@@ -130,6 +130,38 @@ tasks:
     milestone_id: 4
     status: new
 
+# This is for the timeline view
+timeline:
+  title: Milestones and timeline
+  text: "We will create a custom timeline and list of milestones for
+    you based on information from your
+    [CFPBuy Request # XXX-XXXX-XXX][CFPBuy Request]
+    (**locked**), along with your answers to the following questions."
+  fields:
+    - title: Type of Action
+      value: Task Order / Call
+    - title: "Contract / Agreement #"
+      value: MASCS BPA
+  questions:
+    - title: Does this have T&amp;I implications?
+      name: tni
+      options:
+        - label: "No"
+          value: false
+          selected: true
+        - label: "Yes"
+          value: true
+    - title: Does this involve contractor personnel?
+      name: contractor_personnel
+      options:
+        - label: "None"
+          value: none
+          selected: true
+        - label: "Yes - Onsite"
+          value: onsite
+        - label: "Yes - Offsite"
+          value: offsite
+
 # OPTIONAL: links is an optional list of links to include in the
 # markdownified activity and task content.
 links:

--- a/_procurements/rmr-assessments-bpa.md
+++ b/_procurements/rmr-assessments-bpa.md
@@ -40,7 +40,7 @@ links:
   #    and task messages above.
   - name: Acquisition Package
     # 2. "href": an absolute URI, e.g. "/sprint4b/documents/..."
-    href: "/sprint4b/documents/?title=Acquisition+Package+%23+XXX-XXXX-XXX&locked=true"
+    href: "/sprint4b/document/?title=Acquisition+Package+%23+XXX-XXXX-XXX&locked=true"
 
     # NOTE: quote the name if it contains "#"
 

--- a/sprint4b/index.html
+++ b/sprint4b/index.html
@@ -115,7 +115,7 @@ sort_options:
     <div class="col col-{{ col.right }}"></div>
   </div>
 
-  {% assign tasks = pr.tasks | sort_by: 'date' | reverse %}
+  {% assign tasks = pr.tasks | sort_by: 'date' %}
 
   {% unless tasks.empty %}
   <div class="row upcoming-header">

--- a/sprint4b/timeline/index.html
+++ b/sprint4b/timeline/index.html
@@ -46,7 +46,7 @@ title: " "
 </div>
 
 <main class="content">
-  <form action="{{ site.baseurl }}/sprint4b/" class="wrapper wrapper__match-content">
+  <form action="{{ site.baseurl }}{{ pr.url }}" class="wrapper wrapper__match-content">
     <h2>Milestones and timeline</h2>
 
     {% assign timeline = pr.timeline %}

--- a/sprint4b/timeline/index.html
+++ b/sprint4b/timeline/index.html
@@ -1,0 +1,120 @@
+---
+layout: default
+
+stylesheets:
+- sprint4b.css
+
+scripts:
+- sprint4b/document-detail.js
+
+body_class: 'site__procurement-detail site__procurement-timeline'
+
+subtitle: Name of Program Office / Active Procurements
+title: " "
+
+# This is for the timeline view
+timeline:
+  title: Milestones and timeline
+  text: "We will create a custom timeline and list of milestones for
+    you based on information from your
+    [CFPBuy Request # XXX-XXXX-XXX][CFPBuy Request]
+    (**locked**), along with your answers to the following questions."
+  fields:
+    - title: Type of Action
+      value: Task Order / Call
+    - title: "Contract / Agreement #"
+      value: MASCS BPA
+  questions:
+    - title: Does this have T&amp;I implications?
+      name: t_and_i
+      options:
+        - label: "No"
+          value: false
+          selected: true
+        - label: "Yes"
+          value: true
+    - title: Does this involve contractor personnel?
+      name: contractor_personnel
+      options:
+        - label: "None"
+          value: none
+          selected: true
+        - label: "Yes - Onsite"
+          value: onsite
+        - label: "Yes - Offsite"
+          value: offsite
+
+---
+
+{% assign DATE_FORMAT = '%B %e, %Y' %}
+{% assign LINKS = page.links %}
+{% assign UPCOMING = page.upcoming %}
+
+{% assign proc = site.procurements | where: 'requisition_number': 'FA-956-XXXX' | first %}
+
+<div class="detail-header">
+  <div class="wrapper wrapper__match-content">
+    <div class="row">
+      <div class="col-3">
+        <p class="detail-header__title"><b>Procurement No.</b></p>
+        <p class="detail-header__data">
+          {{ proc.requisition_number }}
+        </p>
+      </div>
+      <div class="col-3">
+        <p class="detail-header__title"><b>Obligated Amount</b></p>
+        <p class="detail-header__data">
+          {{ proc.obligated_value | number_to_currency }}
+        </p>
+      </div>
+      <div class="col-3">
+        <p class="detail-header__title"><b>Award Date</b></p>
+        <p class="detail-header__data">
+          {{ proc.requested_award_date | date: DATE_FORMAT }}
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<main class="content">
+  <form action="{{ site.baseurl }}{{ pr.url }}" class="wrapper wrapper__match-content">
+    <h2>Milestones and timeline</h2>
+
+    {% assign timeline = page.timeline %}
+
+    {%
+      include markdownify.html
+      content=timeline.text
+      links=pr.links
+    %}
+
+    {% for field in timeline.fields %}
+    <h3>{{ field.title }}</h3>
+    <p>{{ field.value }}</p>
+    {% endfor %}
+
+    {% if timeline.questions %}
+    <h3>Additional questions</h3>
+    {% for question in timeline.questions %}
+    <p>{{ question.title }}</p>
+    <p class="question-option">
+      {% for option in question.options %}
+      {% assign option_id = question.name | append: '-' | append: option.value %}
+      <input id="{{ option_id }}" type="radio" name="{{ question.name }}"
+        value="{{ option.value }}"
+        {% if option.selected %}checked{% endif %}>
+      <label class="option btn" for="{{ option_id }}">
+        {{ option.label }}
+      </label>
+      {% endfor %}
+    </p>
+    {% endfor %}
+    {% endif %}
+
+    <button type="submit" class="btn btn__super">
+      Submit
+      <span class="cf-icon cf-icon-right"></span>
+    </button>
+  </form>
+</main>

--- a/sprint4b/timeline/index.html
+++ b/sprint4b/timeline/index.html
@@ -12,45 +12,13 @@ body_class: 'site__procurement-detail site__procurement-timeline'
 subtitle: Name of Program Office / Active Procurements
 title: " "
 
-# This is for the timeline view
-timeline:
-  title: Milestones and timeline
-  text: "We will create a custom timeline and list of milestones for
-    you based on information from your
-    [CFPBuy Request # XXX-XXXX-XXX][CFPBuy Request]
-    (**locked**), along with your answers to the following questions."
-  fields:
-    - title: Type of Action
-      value: Task Order / Call
-    - title: "Contract / Agreement #"
-      value: MASCS BPA
-  questions:
-    - title: Does this have T&amp;I implications?
-      name: t_and_i
-      options:
-        - label: "No"
-          value: false
-          selected: true
-        - label: "Yes"
-          value: true
-    - title: Does this involve contractor personnel?
-      name: contractor_personnel
-      options:
-        - label: "None"
-          value: none
-          selected: true
-        - label: "Yes - Onsite"
-          value: onsite
-        - label: "Yes - Offsite"
-          value: offsite
-
 ---
 
 {% assign DATE_FORMAT = '%B %e, %Y' %}
 {% assign LINKS = page.links %}
 {% assign UPCOMING = page.upcoming %}
 
-{% assign proc = site.procurements | where: 'requisition_number': 'FA-956-XXXX' | first %}
+{% assign pr = site.procurements | where: 'requisition_number': 'FA-956-XXXX' | first %}
 
 <div class="detail-header">
   <div class="wrapper wrapper__match-content">
@@ -58,19 +26,19 @@ timeline:
       <div class="col-3">
         <p class="detail-header__title"><b>Procurement No.</b></p>
         <p class="detail-header__data">
-          {{ proc.requisition_number }}
+          {{ pr.requisition_number }}
         </p>
       </div>
       <div class="col-3">
         <p class="detail-header__title"><b>Obligated Amount</b></p>
         <p class="detail-header__data">
-          {{ proc.obligated_value | number_to_currency }}
+          {{ pr.obligated_value | number_to_currency }}
         </p>
       </div>
       <div class="col-3">
         <p class="detail-header__title"><b>Award Date</b></p>
         <p class="detail-header__data">
-          {{ proc.requested_award_date | date: DATE_FORMAT }}
+          {{ pr.requested_award_date | date: DATE_FORMAT }}
         </p>
       </div>
     </div>
@@ -78,10 +46,10 @@ timeline:
 </div>
 
 <main class="content">
-  <form action="{{ site.baseurl }}{{ pr.url }}" class="wrapper wrapper__match-content">
+  <form action="{{ site.baseurl }}/sprint4b/" class="wrapper wrapper__match-content">
     <h2>Milestones and timeline</h2>
 
-    {% assign timeline = page.timeline %}
+    {% assign timeline = pr.timeline %}
 
     {%
       include markdownify.html

--- a/static/css/sprint4b.scss
+++ b/static/css/sprint4b.scss
@@ -397,3 +397,33 @@ time.due {
   //   }
   // }
 }
+
+.site__procurement-timeline {
+
+  .question-option {
+    input[type=radio] {
+      display: none;
+    }
+
+    input + .btn {
+      background: $gray-60;
+      font-size: 1.2em;
+      margin-right: 1em;
+      min-width: 10em;
+      text-align: center;
+    }
+
+    input:checked + .btn {
+      background: $dark-pacific;
+    }
+  }
+
+  .btn__super {
+    display: block;
+    font-size: 1.7em;
+    margin: 1em auto;
+    min-width: 10em;
+    width: auto;
+  }
+
+}

--- a/static/js/sprint4b/document-detail.js
+++ b/static/js/sprint4b/document-detail.js
@@ -1,15 +1,26 @@
 (function(exports) {
 
   var query = querystring.parse(location.search.substr(1));
+
   console.log('query:', query);
 
-  d3.selectAll('[data-bind]')
+  var templates = d3.selectAll('[data-bind]')
     .datum(function() {
       return this.getAttribute('data-bind');
     })
-    .filter(function(key) { return key in query; })
+    .filter(function(key) { return key in query; });
+
+  templates
+    .filter(function(key) {
+      return typeof query[key] === 'string';
+    })
     .text(function(key) {
       return query[key];
+    });
+
+  templates
+    .each(function(key) {
+      this.setAttribute('data-' + key, query[key]);
     });
 
 })(this);


### PR DESCRIPTION
This introduces a static timeline view at `/sprint4b/timeline/` that mirrors the second page in @femmebot's [wireframes](https://github.com/18F/cfpb-ep-partners/blob/master/sprint4b/sprint4b-wireframes.pdf). It's [hard-coded](https://github.com/18F/cfpb-eprocurement/blob/4fdc7cf9e3e97d96d2ac83416b44e691e4ac8da3/sprint4b/timeline/index.html#L21) to reference the "Enforcement Compliance Orders - BPA Call" procurement, and the text is entirely driven by that procurement's [`timeline` data](https://github.com/18F/cfpb-eprocurement/commit/4fdc7cf9e3e97d96d2ac83416b44e691e4ac8da3). In other words, if you want to change the text on that page, change the data!
