### PR TITLE
Sprint4b tweaks

### DIFF
--- a/_includes/markdownify.html
+++ b/_includes/markdownify.html
@@ -1,8 +1,7 @@
 {% capture _markdown %}
 {{ include.content }}
-
 {% for _link in include.links %}
-[{{ _link.name }}]: {{ site.baseurl }}{{ _link.href }}
-{% endfor %}
+[{{ _link.name }}]: {{ site.baseurl }}{{ _link.href }}{% endfor %}
 {% endcapture %}
 {{ _markdown | markdownify }}
+<!-- {{ _markdown }} -->

--- a/_procurements/enforcement-compliance-orders-bpa-call.md
+++ b/_procurements/enforcement-compliance-orders-bpa-call.md
@@ -114,7 +114,7 @@ tasks:
     due_date: 2016-08-02
     milestone_id: 1
     status: complete
-    upcoming_message: "[Draft IGCE v.1] awaiting review by Catherine (CO)"
+    upcoming_message: "[Draft ICGE v.1] awaiting review by Catherine (CO)"
     upcoming_due_date: 2016-08-10
     upcoming_status: pending
   - message: "[Draft Performance Work Statement] due from Myra (COR)"

--- a/sprint4b/index.html
+++ b/sprint4b/index.html
@@ -124,7 +124,7 @@ sort_options:
 
   {% for task in tasks %}
     {% if task.status != 'complete' %}
-  <div class="row upcoming-header">
+    <div class="row upcoming-header"{% if task.status == 'new' %} hidden{% endif %}>
     <div class="col col-{{ col.left }}">
       {% include due_label.html date=task.due_date %}
     </div>

--- a/static/css/sprint4b.scss
+++ b/static/css/sprint4b.scss
@@ -3,6 +3,10 @@
 
 @import 'palette';
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   font-family: Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
- Only shows "pending" tasks on the aggregate view, so the T&I procurement now looks like this:
  
  ![image](https://cloud.githubusercontent.com/assets/113896/17422125/d2d47cae-5a63-11e6-8b39-dc3610e9abe3.png)
  
  Note that the "new" tasks are still in the DOM but are `hidden`, so we might be able to figure out a lightweight way to flag the tasks differently client-side and show them after they've done the timeline review.
- Fixes a typo in the task list: "IGCE" instead of "ICGE"

cc @femmebot @el-mapache 
